### PR TITLE
Missing import in index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import { Carrier, StorageVolume, DisplayMetrics, RadioAccessTechnology, WCTGeneration } from './deviceinfo.interface';
+import { Address, Carrier, StorageVolume, DisplayMetrics, RadioAccessTechnology, WCTGeneration } from './deviceinfo.interface';
 
 export { RadioAccessTechnology, WCTGeneration };
 


### PR DESCRIPTION
There is a missing import (Address) in index.d.ts. I have the following error when trying to run my app :

ERROR in node_modules/nativescript-dna-deviceinfo/index.d.ts:31:29 - error TS2304: Cannot find name 'Address'.